### PR TITLE
Environment Variables Support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,14 +24,14 @@ module "s3_site" {
 module "lambda_api" {
   source = "github.com/byuawsfhtl/terraform-lambda-api?ref=prd"
 
-  project_name                = var.project_name
-  app_name                    = var.app_name
-  domain                      = local.domain
-  url                         = local.url
-  api_url                     = local.apiUrl
-  ecr_repo                    = var.ecr_repo
-  image_tag                   = var.image_tag
-  lambda_endpoint_definitions = var.lambda_endpoint_definitions
+  project_name                 = var.project_name
+  app_name                     = var.app_name
+  domain                       = local.domain
+  url                          = local.url
+  api_url                      = local.apiUrl
+  ecr_repo                     = var.ecr_repo
+  image_tag                    = var.image_tag
+  lambda_endpoint_definitions  = var.lambda_endpoint_definitions
   lambda_environment_variables = var.lambda_environment_variables
-  function_policies           = var.lambda_policies
+  function_policies            = var.lambda_policies
 }

--- a/main.tf
+++ b/main.tf
@@ -32,5 +32,6 @@ module "lambda_api" {
   ecr_repo                    = var.ecr_repo
   image_tag                   = var.image_tag
   lambda_endpoint_definitions = var.lambda_endpoint_definitions
+  lambda_environment_variables = var.lambda_environment_variables
   function_policies           = var.lambda_policies
 }

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,11 @@ variable "image_tag" {
   description = "The image tag for the Docker image (the timestamp)."
 }
 
+variable "lambda_environment_variables" {
+  type        = map(string)
+  description = "The environment variables to set on the Lambda functions."
+  default     = {}
+}
 variable "lambda_endpoint_definitions" {
   type = list(object({
     path_part       = string


### PR DESCRIPTION
This pull request adds support for setting environment in a lambda function thereby restoring compatibility with the lambda_api terraform module and sets the ENV variable for lambda functions.