### PR TITLE
Memory size implementation

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -40,6 +40,7 @@ variable "lambda_endpoint_definitions" {
       http_method = string
       command     = list(string)
       timeout     = optional(number)
+      memory_size = optional(number)
     }))
   }))
   description = "The definitions for each lambda function."


### PR DESCRIPTION
Just added another optional variable. This should make it so that nothing else breaks in any of our packages, but so it is able to support changing memory size in AWS via code if preferred